### PR TITLE
docs: add unsigned app installation guide and Homebrew cask

### DIFF
--- a/Casks/next-meeting.rb
+++ b/Casks/next-meeting.rb
@@ -1,0 +1,37 @@
+cask "next-meeting" do
+  version "1.0.0"
+  sha256 "PLACEHOLDER_SHA256"
+
+  url "https://github.com/nostrapollo/next-meeting-menu-bar/releases/download/v#{version}/NextMeeting.zip"
+  name "NextMeeting"
+  desc "Menu bar app showing countdown to your next calendar meeting"
+  homepage "https://github.com/nostrapollo/next-meeting-menu-bar"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  app "NextMeeting.app"
+
+  postflight do
+    # Remove quarantine attribute so unsigned app can launch
+    system_command "/usr/bin/xattr",
+                   args: ["-cr", "#{appdir}/NextMeeting.app"],
+                   sudo: false
+  end
+
+  zap trash: [
+    "~/Library/Preferences/com.nostrapollo.NextMeeting.plist",
+    "~/Library/Application Support/NextMeeting",
+  ]
+
+  caveats <<~EOS
+    NextMeeting is an unsigned open source app.
+    
+    If macOS blocks it on first launch:
+      1. Right-click the app → Open → Click "Open"
+      
+    Or run: xattr -cr /Applications/NextMeeting.app
+  EOS
+end

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ brew install --cask next-meeting
 ### Direct Download
 [**Download Latest Release →**](https://github.com/nostrapollo/next-meeting-menu-bar/releases/latest)
 
+> ⚠️ **First launch:** macOS will show a security warning — see [Installing Unsigned Apps](#installing-unsigned-apps) below.
+
 ### Build from Source
 ```bash
 git clone https://github.com/nostrapollo/next-meeting-menu-bar.git
@@ -113,6 +115,38 @@ Optional popup notifications when meetings start — configurable for at-start, 
 
 ### Meeting URL not detected?
 NextMeeting looks for URLs in event titles, notes, location, and URL fields. If your meeting link isn't being found, [open an issue](https://github.com/nostrapollo/next-meeting-menu-bar/issues) with the meeting platform and we'll add support.
+
+## Installing Unsigned Apps
+
+When you first open NextMeeting, macOS will show a warning: *"NextMeeting can't be opened because Apple cannot check it for malicious software."*
+
+**This is normal for independent open source apps.**
+
+### Why isn't it signed?
+
+Apple charges $99/year for a Developer ID certificate required to sign macOS apps. NextMeeting is a free, open source project built by an independent developer — paying Apple $99/year to distribute a free app doesn't make sense.
+
+The app is completely safe. You can [audit every line of code](https://github.com/nostrapollo/next-meeting-menu-bar) yourself.
+
+### How to open it anyway
+
+**Option 1: Right-click to open (easiest)**
+1. Right-click (or Control-click) on NextMeeting.app
+2. Select "Open" from the menu
+3. Click "Open" in the dialog that appears
+
+You only need to do this once. After that, it opens normally.
+
+**Option 2: System Settings**
+1. Try to open the app normally (it will be blocked)
+2. Go to System Settings → Privacy & Security
+3. Scroll down — you'll see "NextMeeting was blocked"
+4. Click "Open Anyway"
+
+**Option 3: Terminal (for power users)**
+```bash
+xattr -cr /Applications/NextMeeting.app
+```
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Adds clear documentation for installing NextMeeting as an unsigned app, plus a ready-to-use Homebrew cask.

## Changes

### README updates
- Added warning note under Direct Download about security dialog
- New **Installing Unsigned Apps** section with:
  - **Why isn't it signed?** — Honest explanation: $99/year for a free open source app doesn't make sense
  - **Three bypass methods:** Right-click, System Settings, Terminal (xattr)

### Homebrew cask
- Added `Casks/next-meeting.rb` ready for homebrew-cask submission
- Includes `postflight` to auto-remove quarantine attribute
- Includes `caveats` explaining the unsigned situation

## Next steps after merge
1. Create a GitHub Release with `NextMeeting.zip`
2. Get SHA256 of the zip
3. Update cask file with real SHA256
4. Submit PR to homebrew/homebrew-cask